### PR TITLE
Patch bug with return value in functions in prompt templates

### DIFF
--- a/python/semantic_kernel/template_engine/blocks/code_block.py
+++ b/python/semantic_kernel/template_engine/blocks/code_block.py
@@ -14,6 +14,7 @@ from semantic_kernel.template_engine.blocks.block_types import BlockTypes
 from semantic_kernel.template_engine.blocks.function_id_block import FunctionIdBlock
 from semantic_kernel.template_engine.blocks.named_arg_block import NamedArgBlock
 from semantic_kernel.template_engine.code_tokenizer import CodeTokenizer
+from semantic_kernel.functions.function_result import FunctionResult
 
 if TYPE_CHECKING:
     from semantic_kernel.functions.kernel_arguments import KernelArguments
@@ -134,6 +135,8 @@ these will be ignored."
             error_msg = f"Error invoking function `{function_block.content}`"
             logger.error(error_msg)
             raise CodeBlockRenderException(error_msg) from exc
+        if isinstance(result, FunctionResult):
+            return str(result.value)
         return str(result) if result else ""
 
     def _enrich_function_arguments(

--- a/python/semantic_kernel/template_engine/blocks/code_block.py
+++ b/python/semantic_kernel/template_engine/blocks/code_block.py
@@ -8,13 +8,13 @@ from pydantic import Field, field_validator, model_validator
 
 from semantic_kernel.exceptions import CodeBlockRenderException, CodeBlockTokenError
 from semantic_kernel.exceptions.kernel_exceptions import KernelFunctionNotFoundError, KernelPluginNotFoundError
+from semantic_kernel.functions.function_result import FunctionResult
 from semantic_kernel.functions.kernel_function_metadata import KernelFunctionMetadata
 from semantic_kernel.template_engine.blocks.block import Block
 from semantic_kernel.template_engine.blocks.block_types import BlockTypes
 from semantic_kernel.template_engine.blocks.function_id_block import FunctionIdBlock
 from semantic_kernel.template_engine.blocks.named_arg_block import NamedArgBlock
 from semantic_kernel.template_engine.code_tokenizer import CodeTokenizer
-from semantic_kernel.functions.function_result import FunctionResult
 
 if TYPE_CHECKING:
     from semantic_kernel.functions.kernel_arguments import KernelArguments


### PR DESCRIPTION
### Motivation and Context

This PR fixes a bug with the returned result in case of an internal function call in a prompt template function.  Open issue: https://github.com/microsoft/semantic-kernel/discussions/10676

### Description

In the template_engine folder, the function the renders an internal function call has a bug. In case the result is a FunctionResult, str(result) does not propagate the correct values. Instead a str(result.value) needs to be performed. 

### Contribution Checklist

- [x] The code builds clean without any errors or warnings
- [x] The PR follows the [SK Contribution Guidelines](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md) and the [pre-submission formatting script](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md#development-scripts) raises no violations
- [x] All unit tests pass, and I have added new tests where possible
- [x] I didn't break anyone :smile:
