### PR TITLE
Enable guardrails for BedrockChatCompletion

### DIFF
--- a/python/semantic_kernel/connectors/ai/bedrock/services/bedrock_chat_completion.py
+++ b/python/semantic_kernel/connectors/ai/bedrock/services/bedrock_chat_completion.py
@@ -5,6 +5,8 @@ from collections.abc import AsyncGenerator, Callable
 from functools import partial
 from typing import TYPE_CHECKING, Any, ClassVar
 
+import os
+
 import boto3
 
 if sys.version_info >= (3, 12):
@@ -208,7 +210,7 @@ class BedrockChatCompletion(BedrockBase, ChatCompletionClientBase):
         Settings are prepared based on the syntax shown here:
         https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/bedrock-runtime/client/converse.html
 
-        Note that Guardrails are not supported.
+        Note that Guardrails are not supported by Semantic Kernel but have been patched in this fork.
         """
         prepared_settings = {
             "modelId": self.ai_model_id,
@@ -229,6 +231,13 @@ class BedrockChatCompletion(BedrockBase, ChatCompletionClientBase):
             prepared_settings["toolConfig"] = {
                 "tools": settings.tools,
                 "toolChoice": settings.tool_choice,
+            }
+
+        # Add Guardrails
+        if os.getenv("ENABLE_GUARDRAILS", False) == "True":
+            prepared_settings["guardrailConfig"] = {
+                "guardrailIdentifier": os.getenv("BEDROCK_GUARDRAIL_ID"),
+                "guardrailVersion": os.getenv("BEDROCK_GUARDRAIL_VERSION")
             }
 
         return prepared_settings

--- a/python/semantic_kernel/connectors/ai/bedrock/services/bedrock_chat_completion.py
+++ b/python/semantic_kernel/connectors/ai/bedrock/services/bedrock_chat_completion.py
@@ -234,7 +234,7 @@ class BedrockChatCompletion(BedrockBase, ChatCompletionClientBase):
             }
 
         # Add Guardrails
-        if os.getenv("ENABLE_GUARDRAILS", False) == "True":
+        if os.getenv("BEDROCK_GUARDRAIL_ID", "") and os.getenv("BEDROCK_GUARDRAIL_VERSION", ""):
             prepared_settings["guardrailConfig"] = {
                 "guardrailIdentifier": os.getenv("BEDROCK_GUARDRAIL_ID"),
                 "guardrailVersion": os.getenv("BEDROCK_GUARDRAIL_VERSION")


### PR DESCRIPTION
### Motivation and Context


Semantic Kernel's Bedrock connector does not include support for Guardrails.

This PR enables Guardrails in calls via BedrockChatCompletion.

### Description

This PR enables Guardrails in calls via BedrockChatCompletion. The Guardrail details are provided via environment variables.


### Contribution Checklist

<!-- Before submitting this PR, please make sure: -->

- [X] The code builds clean without any errors or warnings
- [X] The PR follows the [SK Contribution Guidelines](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md) and the [pre-submission formatting script](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md#development-scripts) raises no violations
- [X] All unit tests pass, and I have added new tests where possible
- [X] I didn't break anyone :smile:
