### PR TITLE
AA-20316 - Fix Support for Parallel Tool Calling in Bedrock

### DIFF
--- a/python/semantic_kernel/connectors/ai/bedrock/services/bedrock_chat_completion.py
+++ b/python/semantic_kernel/connectors/ai/bedrock/services/bedrock_chat_completion.py
@@ -180,10 +180,31 @@ class BedrockChatCompletion(BedrockBase, ChatCompletionClientBase):
     ) -> Any:
         messages: list[dict[str, Any]] = []
 
+        tool_message_buffer = None
         for message in chat_history.messages:
             if message.role == AuthorRole.SYSTEM:
                 continue
-            messages.append(MESSAGE_CONVERTERS[message.role](message))
+
+            # If there are multiple tool responses, Bedrock expects one message
+            # with multiple content blocks, one for each response.
+            if message.role == AuthorRole.TOOL:
+                if tool_message_buffer is None:
+                    tool_message_buffer = MESSAGE_CONVERTERS[message.role](message)
+                else:
+                    tool_message_buffer["content"].extend(
+                        (MESSAGE_CONVERTERS[message.role](message)).get("content", [])
+                    )
+            else:
+                # If a non-tool message is encountered, flush the buffer
+                if tool_message_buffer:
+                    messages.append(tool_message_buffer)
+                    tool_message_buffer = None
+
+                messages.append(MESSAGE_CONVERTERS[message.role](message))
+
+        # Flush any remaining tool messages buffer
+        if tool_message_buffer:
+            messages.append(tool_message_buffer)
 
         return messages
 
@@ -192,31 +213,10 @@ class BedrockChatCompletion(BedrockBase, ChatCompletionClientBase):
     def _prepare_system_messages_for_request(self, chat_history: "ChatHistory") -> Any:
         messages: list[dict[str, Any]] = []
 
-        tool_message_buffer = None
         for message in chat_history.messages:
             if message.role != AuthorRole.SYSTEM:
                 continue
-
-            # If there are multiple tool responses, Bedrock expects one message
-            # with multiple content blocks, one for each response.
-            if message.role == AuthorRole.TOOL:
-                if tool_message_buffer is None:
-                    # Start buffering tool messages
-                    tool_message_buffer = MESSAGE_CONVERTERS[message.role](message)
-                    tool_message_buffer["items"] = tool_message_buffer.get("items", [])
-                else:
-                    # Merge consecutive tool messages
-                    tool_message_buffer["items"].extend(MESSAGE_CONVERTERS[message.role](message).get("items", []))
-            else:
-                # If a non-tool message is encountered, flush the buffer
-                if tool_message_buffer:
-                    messages.append(tool_message_buffer)
-                    tool_message_buffer = None
-                messages.append(MESSAGE_CONVERTERS[message.role](message))
-
-        # Flush any remaining tool message buffer
-        if tool_message_buffer:
-            messages.append(tool_message_buffer)
+            messages.append(MESSAGE_CONVERTERS[message.role](message))
 
         return messages
 

--- a/python/semantic_kernel/connectors/ai/bedrock/services/bedrock_chat_completion.py
+++ b/python/semantic_kernel/connectors/ai/bedrock/services/bedrock_chat_completion.py
@@ -1,11 +1,10 @@
 # Copyright (c) Microsoft. All rights reserved.
 
+import os
 import sys
 from collections.abc import AsyncGenerator, Callable
 from functools import partial
 from typing import TYPE_CHECKING, Any, ClassVar
-
-import os
 
 import boto3
 
@@ -193,10 +192,31 @@ class BedrockChatCompletion(BedrockBase, ChatCompletionClientBase):
     def _prepare_system_messages_for_request(self, chat_history: "ChatHistory") -> Any:
         messages: list[dict[str, Any]] = []
 
+        tool_message_buffer = None
         for message in chat_history.messages:
             if message.role != AuthorRole.SYSTEM:
                 continue
-            messages.append(MESSAGE_CONVERTERS[message.role](message))
+
+            # If there are multiple tool responses, Bedrock expects one message
+            # with multiple content blocks, one for each response.
+            if message.role == AuthorRole.TOOL:
+                if tool_message_buffer is None:
+                    # Start buffering tool messages
+                    tool_message_buffer = MESSAGE_CONVERTERS[message.role](message)
+                    tool_message_buffer["items"] = tool_message_buffer.get("items", [])
+                else:
+                    # Merge consecutive tool messages
+                    tool_message_buffer["items"].extend(MESSAGE_CONVERTERS[message.role](message).get("items", []))
+            else:
+                # If a non-tool message is encountered, flush the buffer
+                if tool_message_buffer:
+                    messages.append(tool_message_buffer)
+                    tool_message_buffer = None
+                messages.append(MESSAGE_CONVERTERS[message.role](message))
+
+        # Flush any remaining tool message buffer
+        if tool_message_buffer:
+            messages.append(tool_message_buffer)
 
         return messages
 
@@ -237,7 +257,7 @@ class BedrockChatCompletion(BedrockBase, ChatCompletionClientBase):
         if os.getenv("BEDROCK_GUARDRAIL_ID", "") and os.getenv("BEDROCK_GUARDRAIL_VERSION", ""):
             prepared_settings["guardrailConfig"] = {
                 "guardrailIdentifier": os.getenv("BEDROCK_GUARDRAIL_ID"),
-                "guardrailVersion": os.getenv("BEDROCK_GUARDRAIL_VERSION")
+                "guardrailVersion": os.getenv("BEDROCK_GUARDRAIL_VERSION"),
             }
 
         return prepared_settings


### PR DESCRIPTION
### Motivation and Context

This PR fixes a bug in semantic-kernel that prevents parallel tool calling in Bedrock. 

Test case:
```
Are there any events or alerts that are currently active?
```

This will trigger a call to both the `get_events` and `get_alert` tools. This will cause Bedrock to generate an error because Semantic Kernel improperly formats the tool response message. 

**Problem**
When sending multiple tool call responses to Bedrock, the Converse API expects a single message with multiple content blocks (one per tool response). However, semantic-kernel instead generates separate user messages for each tool response.

Here are correct and incorrect examples (using pseudo response, not accurate).

Correct example expected by Bedrock Converse API:
```json
{
  "messages": [
    {
      "role": "user",
      "content": [
        {
          "toolResult": {
            "toolUseId": "tooluse_csDR7nnbSuuAlnirY9i7Bg",
            "content": [
              {
                "text": "There are 5 active Events"
              }
            ]
          }
        },
        {
          "toolResult": {
            "toolUseId": "tooluse_ETb1bdSXTQWCxKMpfHzQCA",
            "content": [
              {
                "text": "There are 3 active Alerts"
              }
            ]
          }
        }
      ]
    }
  ]
```

Actual response generated by Semantic Kernel:
```json
{
  "messages": [
    {
      "role": "user",
      "content": [
        {
          "toolResult": {
            "toolUseId": "tooluse_csDR7nnbSuuAlnirY9i7Bg",
            "content": [
              {
                "text": "There are 5 active Events"
              }
            ]
          }
        }
      ]
    },
    {
      "role": "user",
      "content": [
        {
          "toolResult": {
            "toolUseId": "tooluse_ETb1bdSXTQWCxKMpfHzQCA",
            "content": [
              {
                "text": "There are 3 active Alerts"
              }
            ]
          }
        }
      ]
    }
  ],
```

**Solution**
This fix modifies the `_prepare_chat_history_for_request` method in `semantic_kernel.connectors.ai.bedrock.services`, which is the method called for formatting chat completion messages. As it parses the messages it combines any consecutive Tool response messages into a single message.  

 **Note**
I have also verified that commenting out line `176` of `chat_completion_client_base.py`, so that `merge_function_results()` is always called, also fixes this issue. However, it is unclear if always calling this method will result in any unintended side-effects.