### PR TITLE
Added fixes for streaming and streamlining logging for XML-friendly prompts

### DIFF
--- a/python/semantic_kernel/connectors/ai/bedrock/services/bedrock_chat_completion.py
+++ b/python/semantic_kernel/connectors/ai/bedrock/services/bedrock_chat_completion.py
@@ -131,9 +131,12 @@ class BedrockChatCompletion(BedrockBase, ChatCompletionClientBase):
         function_invoke_attempt: int = 0,
     ) -> AsyncGenerator[list["StreamingChatMessageContent"], Any]:
         # Not all models support streaming: check if the model supports streaming before proceeding
-        model_info = await self.get_foundation_model_info(self.ai_model_id)
-        if not model_info.get("responseStreamingSupported"):
-            raise ServiceInvalidRequestError(f"The model {self.ai_model_id} does not support streaming.")
+        # Disabling this check because it throws an error for Claude Sonnet 3.5 model_id
+        # even though the model supports streaming
+
+        #model_info = await self.get_foundation_model_info(self.ai_model_id)
+        #if not model_info.get("responseStreamingSupported"):
+        #    raise ServiceInvalidRequestError(f"The model {self.ai_model_id} does not support streaming.")
 
         if not isinstance(settings, BedrockChatPromptExecutionSettings):
             settings = self.get_prompt_execution_settings_from_settings(settings)

--- a/python/semantic_kernel/contents/chat_history.py
+++ b/python/semantic_kernel/contents/chat_history.py
@@ -279,7 +279,8 @@ class ChatHistory(KernelBaseModel):
         try:
             xml_prompt = XML(text=f"<{prompt_tag}>{prompt}</{prompt_tag}>")
         except ParseError as exc:
-            logger.info(f"Could not parse prompt {prompt} as xml, treating as text, error was: {exc}")
+            # Modifying this logging to exclude returning the entire prompt
+            logger.info(f"Could not parse prompt as xml, treating as text, error was: {exc}")
             return cls(messages=[ChatMessageContent(role=AuthorRole.USER, content=unescape(prompt))])
         if xml_prompt.text and xml_prompt.text.strip():
             messages.append(ChatMessageContent(role=AuthorRole.SYSTEM, content=unescape(xml_prompt.text.strip())))


### PR DESCRIPTION
This PR introduces 2 fixes: 

1. Disable checks for whether the model_id supports streaming (this throws an error with existing Claude model)
2. Streamline logging by removing the prompt from XML-related INFO logging