### PR TITLE
Add missing index for FunctionCallContent in streaming with Bedrock

### DIFF
--- a/python/semantic_kernel/connectors/ai/bedrock/services/bedrock_chat_completion.py
+++ b/python/semantic_kernel/connectors/ai/bedrock/services/bedrock_chat_completion.py
@@ -360,6 +360,7 @@ class BedrockChatCompletion(BedrockBase, ChatCompletionClientBase):
                     name=format_bedrock_function_name_to_kernel_function_fully_qualified_name(
                         event["contentBlockStart"]["start"]["toolUse"]["name"]
                     ),
+                    index=event["contentBlockStart"]["contentBlockIndex"],
                 )
             )
 
@@ -389,6 +390,7 @@ class BedrockChatCompletion(BedrockBase, ChatCompletionClientBase):
             else FunctionCallContent(
                 arguments=event["contentBlockDelta"]["delta"]["toolUse"]["input"],
                 inner_content=event,
+                index=event["contentBlockDelta"]["contentBlockIndex"],
             )
         ]
 


### PR DESCRIPTION
Tool calls using a Bedrock hosted LLM in streaming mode are broken when there are multiple tools being called, since parameters of the different tools are appended. This PR makes sure that the `contentBlockIndex` is used when instantiating `FunctionCallContent`, to make sure that parameters from different tools are not mixed.
