### PR TITLE
Add prompt caching for system messages and tools

### DIFF
--- a/python/semantic_kernel/connectors/ai/bedrock/services/bedrock_chat_completion.py
+++ b/python/semantic_kernel/connectors/ai/bedrock/services/bedrock_chat_completion.py
@@ -232,11 +232,10 @@ class BedrockChatCompletion(BedrockBase, ChatCompletionClientBase):
 
         if settings.tools and settings.tool_choice:
             # Add Prompt caching for Tools
-            tools = settings.tools
             if os.getenv("MODEL_ID") in MODELS_WITH_PROMPT_CACHING:
-                tools.append({"cachePoint": {"type": "default"}})
+                settings.tools.append({"cachePoint": {"type": "default"}})
             prepared_settings["toolConfig"] = {
-                "tools": tools,
+                "tools": settings.tools,
                 "toolChoice": settings.tool_choice,
             }
 

--- a/python/semantic_kernel/connectors/ai/bedrock/services/bedrock_chat_completion.py
+++ b/python/semantic_kernel/connectors/ai/bedrock/services/bedrock_chat_completion.py
@@ -4,7 +4,7 @@ import sys
 from collections.abc import AsyncGenerator, Callable
 from functools import partial
 from typing import TYPE_CHECKING, Any, ClassVar
-
+import os
 import boto3
 
 if sys.version_info >= (3, 12):
@@ -197,7 +197,8 @@ class BedrockChatCompletion(BedrockBase, ChatCompletionClientBase):
             messages.append(MESSAGE_CONVERTERS[message.role](message))
 
         # Add Prompt caching for SYSTEM messages
-        messages.append({"cachePoint": {"type": "default"}})
+        if "claude-3-7-sonnet" in os.getenv("MODEL_ID"):
+            messages.append({"cachePoint": {"type": "default"}})
 
         return messages
 
@@ -231,7 +232,8 @@ class BedrockChatCompletion(BedrockBase, ChatCompletionClientBase):
         if settings.tools and settings.tool_choice:
             # Add Prompt caching for Tools
             tools = settings.tools
-            tools.append({"cachePoint": {"type": "default"}})
+            if "claude-3-7-sonnet" in os.getenv("MODEL_ID"):
+                tools.append({"cachePoint": {"type": "default"}})
             prepared_settings["toolConfig"] = {
                 "tools": tools,
                 "toolChoice": settings.tool_choice,

--- a/python/semantic_kernel/connectors/ai/bedrock/services/bedrock_chat_completion.py
+++ b/python/semantic_kernel/connectors/ai/bedrock/services/bedrock_chat_completion.py
@@ -196,6 +196,9 @@ class BedrockChatCompletion(BedrockBase, ChatCompletionClientBase):
                 continue
             messages.append(MESSAGE_CONVERTERS[message.role](message))
 
+        # Add Prompt caching for SYSTEM messages
+        messages.append({"cachePoint": {"type": "default"}})
+
         return messages
 
     def _prepare_settings_for_request(
@@ -226,8 +229,11 @@ class BedrockChatCompletion(BedrockBase, ChatCompletionClientBase):
         }
 
         if settings.tools and settings.tool_choice:
+            # Add Prompt caching for Tools
+            tools = settings.tools
+            tools.append({"cachePoint": {"type": "default"}})
             prepared_settings["toolConfig"] = {
-                "tools": settings.tools,
+                "tools": tools,
                 "toolChoice": settings.tool_choice,
             }
 

--- a/python/semantic_kernel/connectors/ai/bedrock/services/bedrock_chat_completion.py
+++ b/python/semantic_kernel/connectors/ai/bedrock/services/bedrock_chat_completion.py
@@ -55,6 +55,7 @@ if TYPE_CHECKING:
     from semantic_kernel.connectors.ai.prompt_execution_settings import PromptExecutionSettings
     from semantic_kernel.contents.chat_history import ChatHistory
 
+MODELS_WITH_PROMPT_CACHING: list = ["us.anthropic.claude-3-7-sonnet-20250219-v1:0"]
 
 class BedrockChatCompletion(BedrockBase, ChatCompletionClientBase):
     """Amazon Bedrock Chat Completion Service."""
@@ -197,7 +198,7 @@ class BedrockChatCompletion(BedrockBase, ChatCompletionClientBase):
             messages.append(MESSAGE_CONVERTERS[message.role](message))
 
         # Add Prompt caching for SYSTEM messages
-        if "claude-3-7-sonnet" in os.getenv("MODEL_ID"):
+        if os.getenv("MODEL_ID") in MODELS_WITH_PROMPT_CACHING:
             messages.append({"cachePoint": {"type": "default"}})
 
         return messages
@@ -232,7 +233,7 @@ class BedrockChatCompletion(BedrockBase, ChatCompletionClientBase):
         if settings.tools and settings.tool_choice:
             # Add Prompt caching for Tools
             tools = settings.tools
-            if "claude-3-7-sonnet" in os.getenv("MODEL_ID"):
+            if os.getenv("MODEL_ID") in MODELS_WITH_PROMPT_CACHING:
                 tools.append({"cachePoint": {"type": "default"}})
             prepared_settings["toolConfig"] = {
                 "tools": tools,


### PR DESCRIPTION
This PR introduces prompt caching for System and Tool messages in the Converse/Converse Stream calls. Currently these are only applied for Claude Sonnet 3.7.

**NOTE**: Prompt caching from AWS Bedrock is currently only available for Claude Sonnet 3.7 and Claude Haiku 3.5
