### PR TITLE
Minor fix for prompt caching of system prompt

### DIFF
--- a/python/semantic_kernel/connectors/ai/bedrock/services/bedrock_chat_completion.py
+++ b/python/semantic_kernel/connectors/ai/bedrock/services/bedrock_chat_completion.py
@@ -224,7 +224,8 @@ class BedrockChatCompletion(BedrockBase, ChatCompletionClientBase):
 
         # Add Prompt caching for SYSTEM messages
         if os.getenv("MODEL_ID") in MODELS_WITH_PROMPT_CACHING:
-            messages.append({"cachePoint": {"type": "default"}})
+            if messages:
+                messages.append({"cachePoint": {"type": "default"}})
 
         return messages
 


### PR DESCRIPTION
This PR fixes a small issue such that prompt caching is added to the SYSTEM prompt messages only when they are non-empty.