### PR TITLE
ML-295: selective guardrails capability for selection prompt

### DIFF
--- a/python/semantic_kernel/connectors/ai/bedrock/services/model_provider/utils.py
+++ b/python/semantic_kernel/connectors/ai/bedrock/services/model_provider/utils.py
@@ -71,7 +71,17 @@ def _format_user_message(message: ChatMessageContent) -> dict[str, Any]:
                 }
             })
         else:
-            contents.append({"text": item.text})
+            text = item.text
+            parts = text.split("Here is the user question:", 1)
+            if len(parts) < 2:
+                return contents.append({"text": text})
+            
+            prompt = parts[0]
+            user_query = parts[1]
+            contents.extend(
+                {"text": prompt},
+                {"guardContent": {"text": {"text": user_query}}},
+            )
 
     return {
         "role": "user",

--- a/python/semantic_kernel/connectors/ai/bedrock/services/model_provider/utils.py
+++ b/python/semantic_kernel/connectors/ai/bedrock/services/model_provider/utils.py
@@ -73,6 +73,9 @@ def _format_user_message(message: ChatMessageContent) -> dict[str, Any]:
         else:
             text = item.text
             parts: list[str] = text.split("Here is the user question:", 1)
+            # atmost two parts are expected, the first part is the prompt and the second part is the user query
+            # only the second part is passed through guardrails
+            # if the delimiter is not found, the entire text is passed through guardrails
             if len(parts) < 2:
                 contents.append({"text": text})
             else:

--- a/python/semantic_kernel/connectors/ai/bedrock/services/model_provider/utils.py
+++ b/python/semantic_kernel/connectors/ai/bedrock/services/model_provider/utils.py
@@ -72,7 +72,7 @@ def _format_user_message(message: ChatMessageContent) -> dict[str, Any]:
             })
         else:
             text = item.text
-            parts = text.split("Here is the user question:", 1)
+            parts: list[str] = text.split("Here is the user question:", 1)
             if len(parts) < 2:
                 contents.append({"text": text})
             else:

--- a/python/semantic_kernel/connectors/ai/bedrock/services/model_provider/utils.py
+++ b/python/semantic_kernel/connectors/ai/bedrock/services/model_provider/utils.py
@@ -74,14 +74,14 @@ def _format_user_message(message: ChatMessageContent) -> dict[str, Any]:
             text = item.text
             parts = text.split("Here is the user question:", 1)
             if len(parts) < 2:
-                return contents.append({"text": text})
-            
-            prompt = parts[0]
-            user_query = parts[1]
-            contents.extend(
-                {"text": prompt},
-                {"guardContent": {"text": {"text": user_query}}},
-            )
+                contents.append({"text": text})
+            else:
+                prompt = parts[0]
+                user_query = parts[1]
+                contents.extend([
+                    {"text": prompt},
+                    {"guardContent": {"text": {"text": user_query}}},
+                ])
 
     return {
         "role": "user",

--- a/python/semantic_kernel/contents/chat_history.py
+++ b/python/semantic_kernel/contents/chat_history.py
@@ -313,6 +313,9 @@ class ChatHistory(KernelBaseModel):
         prompt_tag = "root"
         messages: list["ChatMessageContent"] = []
         prompt = rendered_prompt.strip()
+        # currently the prompts are not XML-complete, so the except block is expected to be hit
+        # in future in case prompts become XML-complete, this part needs to be visited to ensure it behaves
+        # as expected and necessary changes will have to be made
         try:
             xml_prompt = XML(text=f"<{prompt_tag}>{prompt}</{prompt_tag}>")
         except ParseError as exc:


### PR DESCRIPTION
### Motivation and Context

selective application of guardrails so that only a portion of selection prompt including the user input gets passed to Guardrails, while the rest does not go through Guardrail giving the freedom to modify as necessary

### Description

the selection prompt has the piece of text - `Here is the user question:` after which user input is appended and passed as one string for guardrail application. based on the first occurence of this piece of text, the text after will be passed for guardrail to be applied anything before does not go through guardrail, allowing full freedom to modify the system prompt by the ai-assistant team developers. 

### Test Plan:
use the latests changes in the gateway service, try three different scenarios:
-no modification to selection prompt: expected: guardrail not activated, actual: guardrail not activated
-inappropriate content in the user input: expected guardrail activated, actual: guardrail activated
-inappropriate content outside the user input: expected: guardrail not activated, actual: guardrail not activated