### PR TITLE
Revert "Merge pull request #10 from thousandeyes/input-tagging"

### DIFF
--- a/python/semantic_kernel/connectors/ai/bedrock/services/model_provider/utils.py
+++ b/python/semantic_kernel/connectors/ai/bedrock/services/model_provider/utils.py
@@ -71,20 +71,7 @@ def _format_user_message(message: ChatMessageContent) -> dict[str, Any]:
                 }
             })
         else:
-            text = item.text
-            parts: list[str] = text.split("Here is the user question:", 1)
-            # atmost two parts are expected, the first part is the prompt and the second part is the user query
-            # only the second part is passed through guardrails
-            # if the delimiter is not found, the entire text is passed through guardrails
-            if len(parts) < 2:
-                contents.append({"text": text})
-            else:
-                prompt = parts[0]
-                user_query = parts[1]
-                contents.extend([
-                    {"text": prompt},
-                    {"guardContent": {"text": {"text": user_query}}},
-                ])
+            contents.append({"text": item.text})
 
     return {
         "role": "user",

--- a/python/semantic_kernel/contents/chat_history.py
+++ b/python/semantic_kernel/contents/chat_history.py
@@ -313,9 +313,6 @@ class ChatHistory(KernelBaseModel):
         prompt_tag = "root"
         messages: list["ChatMessageContent"] = []
         prompt = rendered_prompt.strip()
-        # currently the prompts are not XML-complete, so the except block is expected to be hit
-        # in future in case prompts become XML-complete, this part needs to be visited to ensure it behaves
-        # as expected and necessary changes will have to be made
         try:
             xml_prompt = XML(text=f"<{prompt_tag}>{prompt}</{prompt_tag}>")
         except ParseError as exc:


### PR DESCRIPTION
This reverts commit 9a052e8dcac8f17fd1d5706afb746cdc9e0b554d, reversing changes made to e4804d50210620fd43985963877a4ca1e8341433.

### Motivation and Context

<!-- Thank you for your contribution to the semantic-kernel repo!
Please help reviewers and future users, providing the following information:
  1. Why is this change required?
  2. What problem does it solve?
  3. What scenario does it contribute to?
  4. If it fixes an open issue, please link to the issue here.
-->

### Description

<!-- Describe your changes, the overall approach, the underlying design.
     These notes will help understanding how your code works. Thanks! -->

### Contribution Checklist

<!-- Before submitting this PR, please make sure: -->

- [ ] The code builds clean without any errors or warnings
- [ ] The PR follows the [SK Contribution Guidelines](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md) and the [pre-submission formatting script](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md#development-scripts) raises no violations
- [ ] All unit tests pass, and I have added new tests where possible
- [ ] I didn't break anyone :smile:
